### PR TITLE
[guppy] add link from readme to documentation

### DIFF
--- a/guppy/README.md
+++ b/guppy/README.md
@@ -1,6 +1,6 @@
 # guppy
 
-[![Build Status](https://circleci.com/gh/calibra/cargo-guppy/tree/master.svg?style=shield)](https://circleci.com/gh/calibra/cargo-guppy/tree/master) [![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE) [![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
+[![Documentation (master)](https://img.shields.io/badge/docs-master-brightgreen)](https://calibra.github.io/cargo-guppy/guppy/) [![Build Status](https://circleci.com/gh/calibra/cargo-guppy/tree/master.svg?style=shield)](https://circleci.com/gh/calibra/cargo-guppy/tree/master) [![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE) [![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
 
 Track and query Cargo dependency graphs.
 

--- a/guppy/README.tpl
+++ b/guppy/README.tpl
@@ -1,6 +1,6 @@
 # {{crate}}
 
-[![Build Status](https://circleci.com/gh/calibra/cargo-guppy/tree/master.svg?style=shield)](https://circleci.com/gh/calibra/cargo-guppy/tree/master) [![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE) [![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
+[![Documentation (master)](https://img.shields.io/badge/docs-master-brightgreen)](https://calibra.github.io/cargo-guppy/guppy/) [![Build Status](https://circleci.com/gh/calibra/cargo-guppy/tree/master.svg?style=shield)](https://circleci.com/gh/calibra/cargo-guppy/tree/master) [![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE) [![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
 
 {{readme}}
 
@@ -12,4 +12,3 @@ See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
 
 This project is available under the terms of either the [Apache 2.0 license](../LICENSE-APACHE) or the [MIT
 license](../LICENSE-MIT).
-


### PR DESCRIPTION
The documentation for `master` is hosted on GitHub Pages and automatically updated through CI. Adda link to it.