### PR TITLE
[guppy] move example snippets into examples dir

### DIFF
--- a/guppy/README.md
+++ b/guppy/README.md
@@ -19,12 +19,11 @@ guppy = "0.1"
 
 ## Examples
 
-Print out all direct and transitive dependencies of a package:
+Print out all direct dependencies of a package:
 
 ```rust
 use guppy::graph::PackageGraph;
 use cargo_metadata::PackageId;
-use std::iter;
 
 // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
 let fixture = include_str!("../fixtures/metadata1.json");
@@ -40,79 +39,10 @@ for link in package_graph.dep_links(&package_id).unwrap() {
     // whether this is a build dependency.
     println!("direct dependency: {}", link.to.id());
 }
-
-// Transitive dependencies are obtained through the `select_` APIs. They are always presented in
-// topological order.
-let select = package_graph.select_transitive_deps(iter::once(&package_id)).unwrap();
-for dep_id in select.into_iter_ids(None) {
-    // The select API also has an `into_iter_links()` method which returns links instead of IDs.
-    println!("transitive dependency: {}", dep_id);
-}
 ```
 
-Remove all links that are dev-only, except for links within workspace packages.
-
-```rust
-use guppy::graph::PackageGraph;
-
-// `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
-let fixture = include_str!("../fixtures/metadata_libra.json");
-let mut package_graph = PackageGraph::from_json(fixture).unwrap();
-
-// `retain_edges` takes a closure that returns `true` if this edge should be kept in the graph.
-package_graph.retain_edges(|data, link| {
-    // 'data' contains metadata for every package. It isn't used in this example but some
-    // complex filters may make use of it.
-    if link.from.in_workspace() && link.to.in_workspace() {
-        return true;
-    }
-    !link.edge.dev_only()
-});
-
-// Iterate over all links and assert that there are no dev-only links.
-for link in package_graph.select_all().into_iter_links(None) {
-    if !link.from.in_workspace() || !link.to.in_workspace() {
-        assert!(!link.edge.dev_only());
-    }
-}
-```
-
-Print out a `dot` graph representing workspace packages, for formatting with
-[graphviz](https://www.graphviz.org/).
-
-```rust
-use guppy::graph::{DependencyLink, DotWrite, PackageDotVisitor, PackageGraph, PackageMetadata};
-use std::fmt;
-
-// `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
-let fixture = include_str!("../fixtures/metadata_libra.json");
-let package_graph = PackageGraph::from_json(fixture).unwrap();
-
-// Non-workspace packages cannot depend on packages within the workspace, so the reverse
-// transitive deps of workspace packages are exactly the set of workspace packages.
-let select = package_graph
-    .select_transitive_reverse_deps(package_graph.workspace().member_ids())
-    .unwrap();
-
-// Define a visitor, which specifies what strings to print out for the graph.
-struct PackageNameVisitor;
-
-impl PackageDotVisitor for PackageNameVisitor {
-    fn visit_package(&self, package: &PackageMetadata, mut f: DotWrite<'_, '_>) -> fmt::Result {
-        write!(f, "{}", package.name())
-    }
-
-    fn visit_link(&self, link: DependencyLink<'_>, f: DotWrite<'_, '_>) -> fmt::Result {
-        // Don't print out anything for links. One could print out e.g. whether this is
-        // a dev-only link.
-        Ok(())
-    }
-}
-
-// select.into_dot() implements `std::fmt::Display`, so it can be written out to a file, a
-// string, stdout, etc.
-let dot_graph = format!("{}", select.into_dot(PackageNameVisitor));
-```
+For more examples, see
+[the `examples` directory](https://github.com/calibra/cargo-guppy/tree/master/guppy/examples).
 
 ## Contributing
 

--- a/guppy/examples/deps.rs
+++ b/guppy/examples/deps.rs
@@ -1,0 +1,34 @@
+//! Print out direct and transitive dependencies of a package.
+
+use cargo_metadata::PackageId;
+use guppy::graph::PackageGraph;
+use guppy::Error;
+use std::iter;
+
+fn main() -> Result<(), Error> {
+    // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
+    let fixture = include_str!("../fixtures/metadata1.json");
+    let package_graph = PackageGraph::from_json(fixture)?;
+
+    // `guppy` provides several ways to get hold of package IDs. Use a pre-defined one for this
+    // example.
+    let package_id = PackageId {
+        repr: "testcrate 0.1.0 (path+file:///fakepath/testcrate)".into(),
+    };
+    // dep_links returns all direct dependencies of a package, and it returns `None` if the package
+    // ID isn't recognized.
+    for link in package_graph.dep_links(&package_id).unwrap() {
+        // A dependency link contains `from`, `to` and `edge`. The edge has information about e.g.
+        // whether this is a build dependency.
+        println!("direct: {}", link.to.id());
+    }
+
+    // Transitive dependencies are obtained through the `select_` APIs. They are always presented in
+    // topological order.
+    let select = package_graph.select_transitive_deps(iter::once(&package_id))?;
+    for dep_id in select.into_iter_ids(None) {
+        // The select API also has an `into_iter_links()` method which returns links instead of IDs.
+        println!("transitive: {}", dep_id);
+    }
+    Ok(())
+}

--- a/guppy/examples/print_dot.rs
+++ b/guppy/examples/print_dot.rs
@@ -1,0 +1,53 @@
+//! Print out a dot representation of a subgraph, for formatting with graphviz.
+//!
+//! This example prints out a dot representation of the dependencies between all packages in a
+//! workspace. It skips over any non-workspace packages.
+//!
+//! Try running this example with graphviz:
+//!
+//! ```text
+//! cargo run --example print_dot > graph.dot
+//! dot -Tpng graph.dot -o graph.png
+//! ```
+
+use guppy::graph::{DependencyLink, DotWrite, PackageDotVisitor, PackageGraph, PackageMetadata};
+use guppy::Error;
+use std::fmt;
+
+// Define a visitor, which specifies what strings to print out for the graph.
+struct PackageNameVisitor;
+
+impl PackageDotVisitor for PackageNameVisitor {
+    fn visit_package(&self, package: &PackageMetadata, mut f: DotWrite<'_, '_>) -> fmt::Result {
+        // Print out the name of the package. Other metadata can also be printed out.
+        //
+        // If you need to look at data for other packages, store a reference to the PackageGraph in
+        // the visitor.
+        write!(f, "{}", package.name())
+    }
+
+    fn visit_link(&self, link: DependencyLink<'_>, mut f: DotWrite<'_, '_>) -> fmt::Result {
+        if link.edge.dev_only() {
+            write!(f, "dev-only")
+        } else {
+            // Don't print out anything if this isn't a dev-only link.
+            Ok(())
+        }
+    }
+}
+
+fn main() -> Result<(), Error> {
+    // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
+    let fixture = include_str!("../fixtures/metadata_libra.json");
+    let package_graph = PackageGraph::from_json(fixture)?;
+
+    // Non-workspace packages cannot depend on packages within the workspace, so the reverse
+    // transitive deps of workspace packages are exactly the set of workspace packages.
+    let select =
+        package_graph.select_transitive_reverse_deps(package_graph.workspace().member_ids())?;
+
+    // select.into_dot() implements `std::fmt::Display`, so it can be written out to a file, a
+    // string, stdout, etc.
+    println!("{}", select.into_dot(PackageNameVisitor));
+    Ok(())
+}

--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -1,0 +1,62 @@
+//! Remove all dependency links that are dev-only.
+//!
+//! Dev-only dependencies are typically not included in release builds, so it's useful to be able
+//! to filter out those links.
+
+use guppy::graph::PackageGraph;
+use guppy::Error;
+use std::iter;
+
+fn main() -> Result<(), Error> {
+    // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
+    let fixture = include_str!("../fixtures/metadata_libra.json");
+    let mut package_graph = PackageGraph::from_json(fixture)?;
+
+    // Pick an important binary package and compute the number of dependencies.
+    //
+    // A clone is typically not required but in this case we're mutating the graph, so we need to
+    // release the immutatable borrow.
+    let libra_node_id = package_graph
+        .workspace()
+        .member_by_path("libra-node")
+        .unwrap()
+        .clone();
+
+    let before_count = package_graph
+        .select_transitive_deps(iter::once(&libra_node_id))?
+        .into_iter_ids(None)
+        .count();
+    println!("number of packages before: {}", before_count);
+
+    // `retain_edges` takes a closure that returns `true` if this edge should be kept in the graph.
+    package_graph.retain_edges(|_data, link| {
+        // '_data' contains metadata for every package. It isn't used in this example but some
+        // complex filters may make use of it.
+
+        if link.edge.dev_only() {
+            println!(
+                "filtering out dev-only link: {} -> {}",
+                link.from.name(),
+                link.to.name()
+            );
+            return false;
+        }
+        true
+    });
+
+    // Iterate over all links and assert that there are no dev-only links.
+    for link in package_graph.select_all().into_iter_links(None) {
+        if !link.from.in_workspace() || !link.to.in_workspace() {
+            assert!(!link.edge.dev_only());
+        }
+    }
+
+    // Count the number of packages after.
+    let after_count = package_graph
+        .select_transitive_deps(iter::once(&libra_node_id))?
+        .into_iter_ids(None)
+        .count();
+    println!("number of packages after: {}", after_count);
+
+    Ok(())
+}

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -18,12 +18,11 @@
 //!
 //! # Examples
 //!
-//! Print out all direct and transitive dependencies of a package:
+//! Print out all direct dependencies of a package:
 //!
 //! ```
 //! use guppy::graph::PackageGraph;
 //! use cargo_metadata::PackageId;
-//! use std::iter;
 //!
 //! // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
 //! let fixture = include_str!("../fixtures/metadata1.json");
@@ -39,79 +38,10 @@
 //!     // whether this is a build dependency.
 //!     println!("direct dependency: {}", link.to.id());
 //! }
-//!
-//! // Transitive dependencies are obtained through the `select_` APIs. They are always presented in
-//! // topological order.
-//! let select = package_graph.select_transitive_deps(iter::once(&package_id)).unwrap();
-//! for dep_id in select.into_iter_ids(None) {
-//!     // The select API also has an `into_iter_links()` method which returns links instead of IDs.
-//!     println!("transitive dependency: {}", dep_id);
-//! }
 //! ```
 //!
-//! Remove all links that are dev-only, except for links within workspace packages.
-//!
-//! ```
-//! use guppy::graph::PackageGraph;
-//!
-//! // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
-//! let fixture = include_str!("../fixtures/metadata_libra.json");
-//! let mut package_graph = PackageGraph::from_json(fixture).unwrap();
-//!
-//! // `retain_edges` takes a closure that returns `true` if this edge should be kept in the graph.
-//! package_graph.retain_edges(|data, link| {
-//!     // 'data' contains metadata for every package. It isn't used in this example but some
-//!     // complex filters may make use of it.
-//!     if link.from.in_workspace() && link.to.in_workspace() {
-//!         return true;
-//!     }
-//!     !link.edge.dev_only()
-//! });
-//!
-//! // Iterate over all links and assert that there are no dev-only links.
-//! for link in package_graph.select_all().into_iter_links(None) {
-//!     if !link.from.in_workspace() || !link.to.in_workspace() {
-//!         assert!(!link.edge.dev_only());
-//!     }
-//! }
-//! ```
-//!
-//! Print out a `dot` graph representing workspace packages, for formatting with
-//! [graphviz](https://www.graphviz.org/).
-//!
-//! ```
-//! use guppy::graph::{DependencyLink, DotWrite, PackageDotVisitor, PackageGraph, PackageMetadata};
-//! use std::fmt;
-//!
-//! // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
-//! let fixture = include_str!("../fixtures/metadata_libra.json");
-//! let package_graph = PackageGraph::from_json(fixture).unwrap();
-//!
-//! // Non-workspace packages cannot depend on packages within the workspace, so the reverse
-//! // transitive deps of workspace packages are exactly the set of workspace packages.
-//! let select = package_graph
-//!     .select_transitive_reverse_deps(package_graph.workspace().member_ids())
-//!     .unwrap();
-//!
-//! // Define a visitor, which specifies what strings to print out for the graph.
-//! struct PackageNameVisitor;
-//!
-//! impl PackageDotVisitor for PackageNameVisitor {
-//!     fn visit_package(&self, package: &PackageMetadata, mut f: DotWrite<'_, '_>) -> fmt::Result {
-//!         write!(f, "{}", package.name())
-//!     }
-//!
-//!     fn visit_link(&self, link: DependencyLink<'_>, f: DotWrite<'_, '_>) -> fmt::Result {
-//!         // Don't print out anything for links. One could print out e.g. whether this is
-//!         // a dev-only link.
-//!         Ok(())
-//!     }
-//! }
-//!
-//! // select.into_dot() implements `std::fmt::Display`, so it can be written out to a file, a
-//! // string, stdout, etc.
-//! let dot_graph = format!("{}", select.into_dot(PackageNameVisitor));
-//! ```
+//! For more examples, see
+//! [the `examples` directory](https://github.com/calibra/cargo-guppy/tree/master/guppy/examples).
 
 pub mod config;
 pub mod diff;


### PR DESCRIPTION
This means users can easily run these examples with `cargo run --example foo`.