### PR TITLE
[guppy] small fix to remove_dev_only example

### DIFF
--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -49,9 +49,7 @@ fn main() -> Result<(), Error> {
 
     // Iterate over all links and assert that there are no dev-only links.
     for link in package_graph.select_all().into_iter_links(None) {
-        if !link.from.in_workspace() || !link.to.in_workspace() {
-            assert!(!link.edge.dev_only());
-        }
+        assert!(!link.edge.dev_only());
     }
 
     // Count the number of packages after.


### PR DESCRIPTION
We filter out all dev-only links, not just those within the workspace.