### PR TITLE
[guppy] fix keywords

### DIFF
--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "guppy"
-version = "0.1.0"
+version = "0.1.1"
 description = "Track and query Cargo dependency graphs."
 documentation = "https://docs.rs/guppy"
 repository = "https://github.com/calibra/cargo-guppy"
 authors = ["Rain <rain1@calibra.com>", "Brandon Williams <bmwill@calibra.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-keywords = ["cargo", "dependencies", "dependency graph", "graphviz"]
+keywords = ["cargo", "dependencies", "reverse-dependencies", "dependency-graph", "graphviz"]
 categories = ["config", "data-structures", "development-tools", "parser-implementations"]
 edition = "2018"
 exclude = [


### PR DESCRIPTION
This prevented version 0.1.0 from being published. Updated the version number as well.