### PR TITLE
cargo guppy commandline improvements

### DIFF
--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -4,10 +4,7 @@
 use anyhow;
 use clap::arg_enum;
 use guppy::{
-    graph::{
-        DependencyDirection, DependencyLink, DotWrite, PackageDotVisitor, PackageGraph,
-        PackageMetadata,
-    },
+    graph::{DependencyLink, DotWrite, PackageDotVisitor, PackageGraph, PackageMetadata},
     MetadataCommand, PackageId,
 };
 use itertools;
@@ -144,13 +141,13 @@ pub fn cmd_select(options: &SelectOptions) -> Result<(), anyhow::Error> {
     // does not handle multiple version of the same package as the current use
     // cases are passing workspace members as the root set, which won't be
     // duplicated.
-    let root_set: HashSet<String> = if options.roots.is_empty() {
+    let root_set: HashSet<String> = if !options.roots.is_empty() {
         options.roots.iter().cloned().collect()
     } else {
         pkg_graph
-            .select_reverse(pkg_graph.workspace().member_ids())?
-            .into_root_metadatas(DependencyDirection::Forward)
-            .map(|meta| meta.name().to_string())
+            .workspace()
+            .member_ids()
+            .map(|pkg_id| pkg_graph.metadata(pkg_id).unwrap().name().to_string())
             .collect()
     };
 

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -43,15 +43,6 @@ pub fn cmd_diff(json: bool, old: &str, new: &str) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-pub fn cmd_count() -> Result<(), anyhow::Error> {
-    let mut command = MetadataCommand::new();
-    let pkg_graph = PackageGraph::from_command(&mut command)?;
-
-    println!("Third-party Packages: {}", pkg_graph.package_count());
-
-    Ok(())
-}
-
 pub fn cmd_dups() -> Result<(), anyhow::Error> {
     let mut command = MetadataCommand::new();
     let pkg_graph = PackageGraph::from_command(&mut command)?;

--- a/cargo-guppy/src/main.rs
+++ b/cargo-guppy/src/main.rs
@@ -21,9 +21,6 @@ enum Command {
         old: String,
         new: String,
     },
-    #[structopt(name = "count")]
-    /// Count the number of third-party deps (non-path)
-    Count,
     #[structopt(name = "dups")]
     /// Print the number of duplicate packages
     Duplicates,
@@ -52,7 +49,6 @@ fn main() {
 
     let result = match args.cmd {
         Command::Diff { json, old, new } => cargo_guppy::cmd_diff(json, &old, &new),
-        Command::Count => cargo_guppy::cmd_count(),
         Command::Duplicates => cargo_guppy::cmd_dups(),
         Command::Select(ref options) => cargo_guppy::cmd_select(options),
         Command::SubtreeSize(ref options) => cargo_guppy::cmd_subtree_size(options),

--- a/cargo-guppy/src/main.rs
+++ b/cargo-guppy/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cargo_guppy::{SelectOptions, SubtreeSizeOptions};
+use cargo_guppy::{FilterOptions, SelectOptions, SubtreeSizeOptions};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -23,7 +23,7 @@ enum Command {
     },
     #[structopt(name = "dups")]
     /// Print the number of duplicate packages
-    Duplicates,
+    Duplicates(FilterOptions),
     #[structopt(name = "select")]
     /// Select packages and their transitive dependencies
     Select(SelectOptions),
@@ -49,7 +49,7 @@ fn main() {
 
     let result = match args.cmd {
         Command::Diff { json, old, new } => cargo_guppy::cmd_diff(json, &old, &new),
-        Command::Duplicates => cargo_guppy::cmd_dups(),
+        Command::Duplicates(ref options) => cargo_guppy::cmd_dups(options),
         Command::Select(ref options) => cargo_guppy::cmd_select(options),
         Command::SubtreeSize(ref options) => cargo_guppy::cmd_subtree_size(options),
     };


### PR DESCRIPTION
While exploring Libra's dependency graph I found some bugs and made a number of improvements:

- enable filter options on dups command
- added filter options for direct third-party dependencies
- remove the count command, which duplicates select and can be replaced by `... | wc -l`
- worked around bug with cyclic graph by iterating over edges instead of nodes
- fixed a bug with root set selection