### PR TITLE
[guppy] use Nested to store SCCs

### DIFF
--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -30,6 +30,7 @@ maintenance = { status = "actively-developed" }
 cargo_metadata = "0.9"
 derivative = "1.0.3"
 fixedbitset = { version = "0.2.0", default-features = false }
+nested = "0.1.1"
 indexmap = "1.3.1"
 once_cell = "1.2.0"
 petgraph = { version = "0.5", default-features = false }

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -633,7 +633,7 @@ impl PackageMetadata {
     ///
     /// This is the same as the `publish` field of `Cargo.toml`.
     pub fn publish(&self) -> Option<&[String]> {
-        self.publish.as_ref().map(|publish| publish.as_slice())
+        self.publish.as_deref()
     }
 
     /// Returns true if this package is in the workspace.
@@ -830,6 +830,6 @@ impl DependencyMetadata {
     /// See [Platform specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
     /// in the Cargo reference for more details.
     pub fn target(&self) -> Option<&str> {
-        self.target.as_ref().map(|x| x.as_str())
+        self.target.as_deref()
     }
 }


### PR DESCRIPTION
A `Nested` can be used to flatten out a `Vec<Vec<T>>` by storing it inline along with indexes. This is perfect for SCCs.

On top of making the code much simpler, this is a nice performance boost:

```
into_iter_ids           time:   [410.64 us 418.96 us 426.89 us]
                        change: [-14.866% -12.965% -10.966%] (p = 0.00 < 0.05)
                        Performance has improved.
```