### PR TITLE
[target-spec] only use the std feature for nom

### DIFF
--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -16,5 +16,5 @@ circle-ci = { repository = "calibra/cargo-guppy", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-nom = "5.0"
+nom = { version = "5.0", default-features = false, features = ["std"] }
 platforms = "0.2"


### PR DESCRIPTION
i.e. don't use the "lexical" feature, which is only used for floats anyway (so is irrelevant to us).

This reduces the size of the dependency graph.