### PR TITLE
a few cleanups

### DIFF
--- a/cargo-guppy/Cargo.toml
+++ b/cargo-guppy/Cargo.toml
@@ -10,6 +10,6 @@ anyhow = "1.0.25"
 clap = "2.33"
 guppy = { version = "0.1.0", path = "../guppy" }
 itertools = "0.9.0"
-serde = "1.0.40"
+serde = { version = "1.0.40", features = ["derive"] }
 serde_json = "1.0.40"
 structopt = "0.3.0"

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -37,7 +37,7 @@ petgraph = { version = "0.5", default-features = false }
 proptest = { version = "0.9", optional = true }
 proptest-derive = { version = "0.1.2", optional = true }
 semver = "0.9.0"
-serde = { version = "1.0.99", features = ["derive"] }
+serde = "1.0.99"
 serde_json = "1.0.40"
 target-spec = { version = "0.1.0", path = "../target-spec" }
 

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -28,7 +28,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 cargo_metadata = "0.9"
-derivative = "2"
 fixedbitset = { version = "0.2.0", default-features = false }
 nested = "0.1.1"
 indexmap = "1.3.1"

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -28,7 +28,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 cargo_metadata = "0.9"
-cfg-expr = { git = "https://github.com/sunshowers/cfg-expr", branch = "logic" }
 derivative = "2"
 fixedbitset = { version = "0.2.0", default-features = false }
 nested = "0.1.1"

--- a/guppy/src/debug_ignore.rs
+++ b/guppy/src/debug_ignore.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+
+/// A newtype wrapper that causes this field to be ignored while being debugged.
+///
+/// Similar to `#[derivative(ignore)]`, but avoids an extra dependency.
+#[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct DebugIgnore<T>(pub(crate) T);
+
+impl<T> Deref for DebugIgnore<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for DebugIgnore<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> fmt::Debug for DebugIgnore<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "...")
+    }
+}

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -6,7 +6,6 @@ use crate::graph::{cargo_version_matches, kind_str, Cycles, DependencyDirection,
 use crate::petgraph_support::scc::Sccs;
 use crate::{Error, JsonValue, Metadata, MetadataCommand, PackageId, Platform};
 use cargo_metadata::{DependencyKind, NodeDep};
-use cfg_expr::expr::Logic;
 use fixedbitset::FixedBitSet;
 use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
@@ -1079,7 +1078,7 @@ impl DependencyReq {
                 if target_matches == Some(true) {
                     return Some(true);
                 }
-                res = Logic::or(res, target_matches);
+                res = k3_or(res, target_matches);
             }
             res
         };
@@ -1132,10 +1131,20 @@ impl TargetPredicate {
                     if matches == Some(true) {
                         return Some(true);
                     }
-                    res = Logic::or(res, matches);
+                    res = k3_or(res, matches);
                 }
                 res
             }
         }
+    }
+}
+
+/// The OR operation for a 3-valued logic with true, false and unknown. One example of this is the
+/// Kleene K3 logic.
+fn k3_or(a: Option<bool>, b: Option<bool>) -> Option<bool> {
+    match (a, b) {
+        (Some(false), Some(false)) => Some(false),
+        (Some(true), _) | (_, Some(true)) => Some(true),
+        _ => None,
     }
 }

--- a/guppy/src/graph/select.rs
+++ b/guppy/src/graph/select.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::debug_ignore::DebugIgnore;
 use crate::graph::{
     DependencyDirection, DependencyEdge, DependencyLink, GraphSpec, PackageGraph, PackageIx,
     PackageMetadata,
@@ -8,7 +9,6 @@ use crate::graph::{
 use crate::petgraph_support::scc::{NodeIter, Sccs};
 use crate::petgraph_support::walk::EdgeDfs;
 use crate::{Error, PackageId};
-use derivative::Derivative;
 use fixedbitset::FixedBitSet;
 use petgraph::graph::IndexType;
 use petgraph::prelude::*;
@@ -196,7 +196,7 @@ impl<'g> PackageSelect<'g> {
         let node_iter = sccs.node_iter(direction.into());
 
         IntoIterIds {
-            graph: dep_graph,
+            graph: DebugIgnore(dep_graph),
             node_iter,
             reachable: prefilter.reachable,
             remaining: prefilter.count,
@@ -292,7 +292,7 @@ impl<'g> PackageSelect<'g> {
         };
 
         IntoIterLinks {
-            package_graph: self.package_graph,
+            package_graph: DebugIgnore(self.package_graph),
             reachable,
             edge_dfs,
             direction,
@@ -421,11 +421,9 @@ pub(super) fn select_postfilter<G: GraphSpec>(
 /// An iterator over package IDs in topological order.
 ///
 /// The items returned are of type `&'g PackageId`. Returned by `PackageSelect::into_iter_ids`.
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, Debug)]
 pub struct IntoIterIds<'g> {
-    #[derivative(Debug = "ignore")]
-    graph: &'g Graph<PackageId, DependencyEdge, Directed, PackageIx>,
+    graph: DebugIgnore<&'g Graph<PackageId, DependencyEdge, Directed, PackageIx>>,
     node_iter: NodeIter<'g, PackageIx>,
     reachable: FixedBitSet,
     remaining: usize,
@@ -505,11 +503,9 @@ impl<'g> ExactSizeIterator for IntoIterMetadatas<'g> {
 /// An iterator over dependency links.
 ///
 /// The items returned are of type `DependencyLink<'g>`. Returned by `PackageSelect::into_iter_ids`.
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, Debug)]
 pub struct IntoIterLinks<'g> {
-    #[derivative(Debug = "ignore")]
-    package_graph: &'g PackageGraph,
+    package_graph: DebugIgnore<&'g PackageGraph>,
     reachable: Option<FixedBitSet>,
     edge_dfs: EdgeDfs<EdgeIndex<PackageIx>, NodeIndex<PackageIx>, FixedBitSet>,
     direction: DependencyDirection,

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -45,6 +45,7 @@
 
 #![warn(missing_docs)]
 
+mod debug_ignore;
 pub mod errors;
 pub mod graph;
 pub(crate) mod petgraph_support;


### PR DESCRIPTION
unfortunately we can't remove `syn` and `quote` altogether from the dependency graph because cargo metadata deserialization relies on them, but we can still speed up build times a bit.